### PR TITLE
fix: console font color change

### DIFF
--- a/src/boot/console-easter-egg.js
+++ b/src/boot/console-easter-egg.js
@@ -4,13 +4,13 @@
 const easterEggs = {
   'hackCycuIce': () => {
     console.log('%c恭喜你發現了控制台彩蛋！', 'color: green; font-size: 20px; font-weight: bold;');
-    console.log('%c輸入以下命令來啟用不同的彩蛋：', 'color: blue;');
+    console.log('%c輸入以下命令來啟用不同的彩蛋：', 'color: cyan;');
     console.log('%c- hackSystem(): 啟動系統破解模式', 'color: red; font-weight: bold;');
     console.log('%c- matrixEffect(): 觸發矩陣效果', 'color: purple;');
     console.log('%c- confettiParty(): 觸發五彩紙屑效果', 'color: purple;');
     console.log('%c- pixelMelt(): 觸發像素融化效果', 'color: orange;');
     console.log('%c- glitchScreen(): 觸發故障效果', 'color: cyan;');
-    console.log('%c- spaceFlight(): 啟動太空飛行', 'color: blue;');
+    console.log('%c- spaceFlight(): 啟動太空飛行', 'color: cyan;');
     console.log('%c- nyanCat(): 彩虹貓彩蛋', 'color: deeppink;');
     return '已解鎖控制台彩蛋命令！';
   },


### PR DESCRIPTION
更換彩蛋在 console 在的字體顏色。
將 blue 換成 cyan，因為在 dark mode 的 browser 會難以閱讀 blue 的字體。
修改前：
![image](https://github.com/user-attachments/assets/a8eddfda-f959-4c23-a554-bc997058d50c)
